### PR TITLE
Add TODO hints for hook script configuration

### DIFF
--- a/scripts/hook_example.sh
+++ b/scripts/hook_example.sh
@@ -3,10 +3,10 @@
 # Inputs: $1=type (e.g., cash_journal), $2=src_csv, $3=dst_csv (fixed)
 set -euo pipefail
 TYPE="$1"; SRC="$2"; DST="$3"
-RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"
-LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"
+RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: actualizar la ruta según la instalación real
+LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"  # TODO: verificar y configurar la ruta de log en producción
 
-python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \
+python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: actualizar la ruta al script ingressfix.py
   --in "$SRC" --out "$DST" --batch-type "$TYPE" --rules "$RULES" \
   --max-errors 0 --strict --log "$LOG"
 # then pass "$DST" to the existing loader...


### PR DESCRIPTION
## Summary
- Add TODO reminders to update RULES path and script invocation in `hook_example.sh`
- Note that log path should be configured for production use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ingressfix')*


------
https://chatgpt.com/codex/tasks/task_e_68a7415bc7a0832dae5d5249205c5119