### PR TITLE
Add date column normalization for batch processing

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,8 +1,8 @@
 {
-  "cash_journal":         { "import_table": "import_cash_journal",         "numeric_cols": ["amount","fee","tax"] },
-  "cash_movement":        { "import_table": "import_cash_movement",        "numeric_cols": ["amount"] },
-  "cash_receipt":         { "import_table": "import_cash_receipt",         "numeric_cols": ["amount"] },
-  "cash":                 { "import_table": "import_cash",                 "numeric_cols": ["amount"] },
+  "cash_journal":         { "import_table": "import_cash_journal",         "numeric_cols": ["amount","fee","tax"], "date_cols": ["txn_date"] },
+  "cash_movement":        { "import_table": "import_cash_movement",        "numeric_cols": ["amount"], "date_cols": ["date"] },
+  "cash_receipt":         { "import_table": "import_cash_receipt",         "numeric_cols": ["amount"], "date_cols": ["date"] },
+  "cash":                 { "import_table": "import_cash",                 "numeric_cols": ["amount"], "date_cols": ["date"] },
   "acats_cash":           { "import_table": "import_acats_cash_movement",  "numeric_cols": ["amount"] },
   "acats_stock":          { "import_table": "import_acats_stock_movement", "numeric_cols": ["qty","price","amount"] },
   "stock_movement":       { "import_table": "import_stock_movement",       "numeric_cols": ["qty","price","amount"] },
@@ -10,9 +10,9 @@
   "seg_req":              { "import_table": "import_seg_requirement",      "numeric_cols": ["requirement","balance","market_value"] },
   "gl_movement":          { "import_table": "import_gl_movement",          "numeric_cols": ["debit","credit","amount","balance"] },
   "trade_cancel":         { "import_table": "import_trade_cancel",         "numeric_cols": ["qty","price","net_amount"] },
-  "trade":                { "import_table": "import_trade",                "numeric_cols": ["qty","price","net_amount"] },
-  "dividend_announce":    { "import_table": "import_dividend_announcement","numeric_cols": ["amount","gross","net","rate"] },
-  "fund_txn":             { "import_table": "import_fund_purchase_redemption","numeric_cols": ["shares","nav","amount"] },
+  "trade":                { "import_table": "import_trade",                "numeric_cols": ["qty","price","net_amount"], "date_cols": ["trade_date","settle_date"] },
+  "dividend_announce":    { "import_table": "import_dividend_announcement","numeric_cols": ["amount","gross","net","rate"], "date_cols": ["ex_date"] },
+  "fund_txn":             { "import_table": "import_fund_purchase_redemption","numeric_cols": ["shares","nav","amount"], "date_cols": ["trade_date"] },
   "reorg_announce":       { "import_table": "import_reorg_announcement",   "numeric_cols": ["ratio","cash_in_lieu"] },
   "account_migration":    { "import_table": "import_account_migration",    "numeric_cols": ["opening_balance","credit_limit"] }
 }


### PR DESCRIPTION
## Summary
- allow optional `date_cols` in rules manifest
- normalize date columns to `YYYY-MM-DD`
- expand tests for valid and invalid date handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7415b26f4832d843b0fe09a84528a