### PR TITLE
Add date column normalization and tests

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,18 +1,152 @@
 {
-  "cash_journal":         { "import_table": "import_cash_journal",         "numeric_cols": ["amount","fee","tax"], "date_cols": ["txn_date"] },
-  "cash_movement":        { "import_table": "import_cash_movement",        "numeric_cols": ["amount"], "date_cols": ["date"] },
-  "cash_receipt":         { "import_table": "import_cash_receipt",         "numeric_cols": ["amount"], "date_cols": ["date"] },
-  "cash":                 { "import_table": "import_cash",                 "numeric_cols": ["amount"], "date_cols": ["date"] },
-  "acats_cash":           { "import_table": "import_acats_cash_movement",  "numeric_cols": ["amount"] },
-  "acats_stock":          { "import_table": "import_acats_stock_movement", "numeric_cols": ["qty","price","amount"] },
-  "stock_movement":       { "import_table": "import_stock_movement",       "numeric_cols": ["qty","price","amount"] },
-  "product":              { "import_table": "import_product",              "numeric_cols": ["price","fee"] },
-  "seg_req":              { "import_table": "import_seg_requirement",      "numeric_cols": ["requirement","balance","market_value"] },
-  "gl_movement":          { "import_table": "import_gl_movement",          "numeric_cols": ["debit","credit","amount","balance"] },
-  "trade_cancel":         { "import_table": "import_trade_cancel",         "numeric_cols": ["qty","price","net_amount"] },
-  "trade":                { "import_table": "import_trade",                "numeric_cols": ["qty","price","net_amount"], "date_cols": ["trade_date","settle_date"] },
-  "dividend_announce":    { "import_table": "import_dividend_announcement","numeric_cols": ["amount","gross","net","rate"], "date_cols": ["ex_date"] },
-  "fund_txn":             { "import_table": "import_fund_purchase_redemption","numeric_cols": ["shares","nav","amount"], "date_cols": ["trade_date"] },
-  "reorg_announce":       { "import_table": "import_reorg_announcement",   "numeric_cols": ["ratio","cash_in_lieu"] },
-  "account_migration":    { "import_table": "import_account_migration",    "numeric_cols": ["opening_balance","credit_limit"] }
+  "cash_journal": {
+    "import_table": "import_cash_journal",
+    "numeric_cols": [
+      "amount",
+      "fee",
+      "tax"
+    ],
+    "date_cols": [
+      "txn_date"
+    ]
+  },
+  "cash_movement": {
+    "import_table": "import_cash_movement",
+    "numeric_cols": [
+      "amount"
+    ],
+    "date_cols": [
+      "date"
+    ]
+  },
+  "cash_receipt": {
+    "import_table": "import_cash_receipt",
+    "numeric_cols": [
+      "amount"
+    ],
+    "date_cols": [
+      "date"
+    ]
+  },
+  "cash": {
+    "import_table": "import_cash",
+    "numeric_cols": [
+      "amount"
+    ],
+    "date_cols": [
+      "date"
+    ]
+  },
+  "acats_cash": {
+    "import_table": "import_acats_cash_movement",
+    "numeric_cols": [
+      "amount"
+    ],
+    "date_cols": []
+  },
+  "acats_stock": {
+    "import_table": "import_acats_stock_movement",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "amount"
+    ],
+    "date_cols": []
+  },
+  "stock_movement": {
+    "import_table": "import_stock_movement",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "amount"
+    ],
+    "date_cols": []
+  },
+  "product": {
+    "import_table": "import_product",
+    "numeric_cols": [
+      "price",
+      "fee"
+    ],
+    "date_cols": []
+  },
+  "seg_req": {
+    "import_table": "import_seg_requirement",
+    "numeric_cols": [
+      "requirement",
+      "balance",
+      "market_value"
+    ],
+    "date_cols": []
+  },
+  "gl_movement": {
+    "import_table": "import_gl_movement",
+    "numeric_cols": [
+      "debit",
+      "credit",
+      "amount",
+      "balance"
+    ],
+    "date_cols": []
+  },
+  "trade_cancel": {
+    "import_table": "import_trade_cancel",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "net_amount"
+    ],
+    "date_cols": []
+  },
+  "trade": {
+    "import_table": "import_trade",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "net_amount"
+    ],
+    "date_cols": [
+      "trade_date",
+      "settle_date"
+    ]
+  },
+  "dividend_announce": {
+    "import_table": "import_dividend_announcement",
+    "numeric_cols": [
+      "amount",
+      "gross",
+      "net",
+      "rate"
+    ],
+    "date_cols": [
+      "ex_date"
+    ]
+  },
+  "fund_txn": {
+    "import_table": "import_fund_purchase_redemption",
+    "numeric_cols": [
+      "shares",
+      "nav",
+      "amount"
+    ],
+    "date_cols": [
+      "trade_date"
+    ]
+  },
+  "reorg_announce": {
+    "import_table": "import_reorg_announcement",
+    "numeric_cols": [
+      "ratio",
+      "cash_in_lieu"
+    ],
+    "date_cols": []
+  },
+  "account_migration": {
+    "import_table": "import_account_migration",
+    "numeric_cols": [
+      "opening_balance",
+      "credit_limit"
+    ],
+    "date_cols": []
+  }
 }

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -24,16 +24,19 @@ def test_normalize_numeric_cell():
 
 def test_normalize_date_cell():
     cases = [
-        ("2023-01-02", "2023-01-02"),
-        ("01/02/2023", "2023-01-02"),
-        ("2023/01/02", "2023-01-02"),
+        ("2023-01-02", "2023-01-02"),      # already ISO
+        ("01/02/2023", "2023-01-02"),      # slashes
+        ("2023/01/02", "2023-01-02"),      # ISO with slashes
+        ("02-03-2023", "2023-02-03"),      # dashes with month first
+        ("20230104", "2023-01-04"),        # compact digits
     ]
     for raw, expected in cases:
         out, changed, bad = normalize_date_cell(raw)
         assert out == expected
         assert not bad
-    out, changed, bad = normalize_date_cell("2023-13-01")
-    assert bad
+    for bad_input in ["2023-13-01", "02/30/2023"]:
+        out, changed, bad = normalize_date_cell(bad_input)
+        assert bad
 
 
 def test_repair_and_sidecar(tmp_path: Path):
@@ -126,7 +129,7 @@ def test_preserve_newline_in_field(tmp_path: Path):
     log = tmp_path / "test.log"
 
     total, repaired, bad = repair_and_write_csv(
-        str(inp), str(out), str(side), set(), str(log), False, 0
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
     )
     assert total == 2 and bad == 0
 


### PR DESCRIPTION
## Summary
- allow batch rules to specify optional `date_cols` alongside numeric columns
- normalize multiple date formats to ISO `YYYY-MM-DD`
- test date normalization and invalid format handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7440887b4832d8984b5b35e07dd53