### PR TITLE
chore: annotate sample hook paths and document production config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ python3 ingressfix.py --in sample.csv --out sample_fixed.csv \
 `hook_example.sh` demonstrates how an upload handler in UBMS DEV will invoke the
 fixer and then pass the `_fixed.csv` file to existing loaders.  TODO markers in
 code note areas that may require adjustments during real deployment.
+
+## Production configuration
+Update placeholder values before deploying:
+
+* Paths in `scripts/hook_example.sh` such as `RULES`, the log file, and the
+  location of `ingressfix.py`.
+* Set the `UBMS_LOG_PATH` environment variable if a different log directory is
+  required.
+* Provide database credentials (`--db-user`, `--db-pass`, `--db-host`, etc.)
+  when using the optional `--load` feature.

--- a/scripts/hook_example.sh
+++ b/scripts/hook_example.sh
@@ -3,10 +3,11 @@
 # Inputs: $1=type (e.g., cash_journal), $2=src_csv, $3=dst_csv (fixed)
 set -euo pipefail
 TYPE="$1"; SRC="$2"; DST="$3"
-RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: actualizar la ruta según la instalación real
+
+RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: actualizar la ruta de RULES según la instalación real
 LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"  # TODO: verificar y configurar la ruta de log en producción
 
-python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: actualizar la ruta al script ingressfix.py
+python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: actualizar la ruta al script ingressfix.py según la instalación real
   --in "$SRC" --out "$DST" --batch-type "$TYPE" --rules "$RULES" \
   --max-errors 0 --strict --log "$LOG"
 # then pass "$DST" to the existing loader...

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -126,7 +126,7 @@ def test_preserve_newline_in_field(tmp_path: Path):
     log = tmp_path / "test.log"
 
     total, repaired, bad = repair_and_write_csv(
-        str(inp), str(out), str(side), set(), str(log), False, 0
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
     )
     assert total == 2 and bad == 0
 


### PR DESCRIPTION
## Summary
- annotate RULES, log, and script paths in `hook_example.sh` with TODO markers for real deployments
- document production-specific path and credential setup in the README
- fix test fixture to match `repair_and_write_csv` signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74406c9c8832da0d533a4fd8c1dca