### PR TITLE
Preserve CSV header formatting

### DIFF
--- a/ingressfix.py
+++ b/ingressfix.py
@@ -236,8 +236,10 @@ def repair_and_write_csv(in_path: str, out_path: str, sidecar_path: str,
             return (0,0,0)
 
         header = next(csv.reader([first_line]))
+        # write the header exactly as read, preserving original newline
+        fout.write(first_line)
+        # writer is only used for subsequent rows
         writer = csv.writer(fout, quoting=csv.QUOTE_ALL)
-        writer.writerow(header)
 
         header_map = {h.strip().lower(): i for i, h in enumerate(header)}
         if numeric_cols:

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -56,6 +56,10 @@ def test_repair_and_sidecar(tmp_path: Path):
     assert total == 3
     assert bad == 2
 
+    # header line should be preserved byte-for-byte
+    with inp.open("rb") as fin, out.open("rb") as fout:
+        assert fin.readline() == fout.readline()
+
     with out.open() as f:
         rows = list(csv.reader(f))
     assert rows[0] == ["account", "amount", "description"]
@@ -126,7 +130,7 @@ def test_preserve_newline_in_field(tmp_path: Path):
     log = tmp_path / "test.log"
 
     total, repaired, bad = repair_and_write_csv(
-        str(inp), str(out), str(side), set(), str(log), False, 0
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
     )
     assert total == 2 and bad == 0
 


### PR DESCRIPTION
## Summary
- Preserve original CSV header line when repairing files
- Verify output header matches the input header byte-for-byte

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74408c040832d9486bf5d5fe76a05