### PR TITLE
Handle raw rows for heuristic rebuild and multiline preservation

### DIFF
--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -126,9 +126,9 @@ def test_preserve_newline_in_field(tmp_path: Path):
     log = tmp_path / "test.log"
 
     total, repaired, bad = repair_and_write_csv(
-        str(inp), str(out), str(side), set(), str(log), False, 0
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
     )
-    assert total == 2 and bad == 0
+    assert total == 2 and repaired == 0 and bad == 0
 
     with out.open() as f:
         rows = list(csv.reader(f))


### PR DESCRIPTION
## Summary
- Rework `repair_and_write_csv` to iterate over `csv.reader` and keep a manual line counter
- Pass raw row strings into `heuristic_rebuild` for accurate column repair
- Ensure descriptions containing newline characters are preserved and counted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a743db8918832da29acc4ab366aff5