### PR TITLE
Handle multiline CSV fields

### DIFF
--- a/ingressfix.py
+++ b/ingressfix.py
@@ -256,9 +256,9 @@ def repair_and_write_csv(in_path: str, out_path: str, sidecar_path: str,
 
         for row in reader:
             line_no += 1
-            raw = ",".join(row)
             if len(row) != expected:
-                rebuilt = heuristic_rebuild(raw, expected, numeric_idx)
+                raw_record = reader.dialect.delimiter.join(row)
+                rebuilt = heuristic_rebuild(raw_record, expected, numeric_idx)
                 if rebuilt is None:
                     unrecoverable += 1
                     if bad_writer is None:

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -141,3 +141,25 @@ def test_preserve_newline_in_field(tmp_path: Path):
         rows = list(csv.reader(f))
     assert len(rows) == 3
     assert rows[1] == ["A1", "line1\nline2"]
+
+
+def test_multiline_field_count(tmp_path: Path):
+    inp = tmp_path / "multiline_count.csv"
+    inp.write_text(
+        "account,description\n"
+        "A1,\"line1\nline2\"\n"
+        "A2,\"second\"\n"
+    )
+    out = tmp_path / "multiline_count_fixed.csv"
+    side = tmp_path / "multiline_count_fixed.unrecoverable.csv"
+    log = tmp_path / "test.log"
+
+    total, repaired, bad = repair_and_write_csv(
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
+    )
+    assert total == 2 and repaired == 0 and bad == 0
+
+    with out.open() as f:
+        rows = list(csv.reader(f))
+    assert rows[1] == ["A1", "line1\nline2"]
+    assert rows[2] == ["A2", "second"]


### PR DESCRIPTION
## Summary
- Iterate over `csv.reader` with manual record counter in `repair_and_write_csv`
- Feed raw record string to `heuristic_rebuild` when column counts mismatch
- Add regression test ensuring newline-containing fields remain intact and properly counted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a747197fec832da87ac4caeb8002df