### PR TITLE
Write header before initializing CSV writer

### DIFF
--- a/ingressfix.py
+++ b/ingressfix.py
@@ -237,9 +237,9 @@ def repair_and_write_csv(in_path: str, out_path: str, sidecar_path: str,
             log_warn("Empty file; nothing to do", log_path)
             return (0,0,0)
 
-        header = next(csv.reader([first_line]))
         # write the header exactly as read, preserving original newline
         fout.write(first_line)
+        header = next(csv.reader([first_line]))
         # writer is only used for subsequent rows
         writer = csv.writer(fout, quoting=csv.QUOTE_ALL)
 

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -76,6 +76,21 @@ def test_repair_and_sidecar(tmp_path: Path):
     assert bad_rows[2] == ["A4", "1"]
 
 
+
+
+def test_header_preserved(tmp_path: Path):
+    inp = tmp_path / 'header.csv'
+    # include CRLF to ensure newline preserved
+    inp.write_bytes(b'col1,col2\r\n1,2\r\n')
+    out = tmp_path / 'header_fixed.csv'
+    side = tmp_path / 'header_fixed.unrecoverable.csv'
+    log = tmp_path / 'test.log'
+
+    total, repaired, bad = repair_and_write_csv(str(inp), str(out), str(side), set(), set(), str(log), False, 0)
+    assert total == 1 and bad == 0
+
+    with inp.open('rb') as fin, out.open('rb') as fout:
+        assert fin.readline() == fout.readline()
 def test_date_normalization(tmp_path: Path):
     inp = tmp_path / "dates.csv"
     inp.write_text(


### PR DESCRIPTION
## Summary
- Preserve original CSV header by writing the first line directly before creating a `csv.writer`
- Add regression test verifying that output header matches input header byte-for-byte

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a748a194c0832db3a2f81a7a50ccfb