### PR TITLE
Add TODO notes for environment-specific paths

### DIFF
--- a/scripts/hook_example.sh
+++ b/scripts/hook_example.sh
@@ -4,10 +4,10 @@
 set -euo pipefail
 TYPE="$1"; SRC="$2"; DST="$3"
 
-RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: actualizar la ruta de RULES según la instalación real
-LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"  # TODO: verificar y configurar la ruta de log en producción
+RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: adjust RULES path for target environment
+LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"  # TODO: configure log path or UBMS_LOG_PATH for target environment
 
-python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: actualizar la ruta al script ingressfix.py según la instalación real
+python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: adjust ingressfix.py path for target environment
   --in "$SRC" --out "$DST" --batch-type "$TYPE" --rules "$RULES" \
   --max-errors 0 --strict --log "$LOG"
 # then pass "$DST" to the existing loader...


### PR DESCRIPTION
## Summary
- Annotate example hook script paths with TODO markers for rules file, log file, and ingressfix script so they can be adjusted per environment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a749b09678832dbef764c81385148b