### PR TITLE
Handle date normalization during CSV repair

### DIFF
--- a/ingressfix.py
+++ b/ingressfix.py
@@ -300,7 +300,10 @@ def repair_and_write_csv(in_path: str, out_path: str, sidecar_path: str,
                     bad_writer = csv.writer(fb, quoting=csv.QUOTE_ALL)
                     bad_writer.writerow(header)
                 bad_writer.writerow(row)
-                log_error(f"Row {line_no} unrecoverable: non-numeric token in numeric col(s); raw saved", log_path)
+                log_error(
+                    f"Row {line_no} unrecoverable: invalid numeric or date value; raw saved",
+                    log_path,
+                )
                 if strict or (max_errors and unrecoverable >= max_errors):
                     return (total, repaired, unrecoverable)
                 continue

--- a/rules.json
+++ b/rules.json
@@ -1,152 +1,152 @@
 {
-  "cash_journal": {
-    "import_table": "import_cash_journal",
-    "numeric_cols": [
-      "amount",
-      "fee",
-      "tax"
-    ],
-    "date_cols": [
-      "txn_date"
-    ]
-  },
-  "cash_movement": {
-    "import_table": "import_cash_movement",
-    "numeric_cols": [
-      "amount"
-    ],
-    "date_cols": [
-      "date"
-    ]
-  },
-  "cash_receipt": {
-    "import_table": "import_cash_receipt",
-    "numeric_cols": [
-      "amount"
-    ],
-    "date_cols": [
-      "date"
-    ]
-  },
-  "cash": {
-    "import_table": "import_cash",
-    "numeric_cols": [
-      "amount"
-    ],
-    "date_cols": [
-      "date"
-    ]
-  },
   "acats_cash": {
+    "date_cols": [],
     "import_table": "import_acats_cash_movement",
     "numeric_cols": [
       "amount"
-    ],
-    "date_cols": []
+    ]
   },
   "acats_stock": {
+    "date_cols": [],
     "import_table": "import_acats_stock_movement",
     "numeric_cols": [
       "qty",
       "price",
       "amount"
-    ],
-    "date_cols": []
+    ]
   },
-  "stock_movement": {
-    "import_table": "import_stock_movement",
+  "account_migration": {
+    "date_cols": [],
+    "import_table": "import_account_migration",
     "numeric_cols": [
-      "qty",
-      "price",
-      "amount"
-    ],
-    "date_cols": []
+      "opening_balance",
+      "credit_limit"
+    ]
   },
-  "product": {
-    "import_table": "import_product",
-    "numeric_cols": [
-      "price",
-      "fee"
-    ],
-    "date_cols": []
-  },
-  "seg_req": {
-    "import_table": "import_seg_requirement",
-    "numeric_cols": [
-      "requirement",
-      "balance",
-      "market_value"
-    ],
-    "date_cols": []
-  },
-  "gl_movement": {
-    "import_table": "import_gl_movement",
-    "numeric_cols": [
-      "debit",
-      "credit",
-      "amount",
-      "balance"
-    ],
-    "date_cols": []
-  },
-  "trade_cancel": {
-    "import_table": "import_trade_cancel",
-    "numeric_cols": [
-      "qty",
-      "price",
-      "net_amount"
-    ],
-    "date_cols": []
-  },
-  "trade": {
-    "import_table": "import_trade",
-    "numeric_cols": [
-      "qty",
-      "price",
-      "net_amount"
-    ],
+  "cash": {
     "date_cols": [
-      "trade_date",
-      "settle_date"
+      "date"
+    ],
+    "import_table": "import_cash",
+    "numeric_cols": [
+      "amount"
+    ]
+  },
+  "cash_journal": {
+    "date_cols": [
+      "txn_date"
+    ],
+    "import_table": "import_cash_journal",
+    "numeric_cols": [
+      "amount",
+      "fee",
+      "tax"
+    ]
+  },
+  "cash_movement": {
+    "date_cols": [
+      "date"
+    ],
+    "import_table": "import_cash_movement",
+    "numeric_cols": [
+      "amount"
+    ]
+  },
+  "cash_receipt": {
+    "date_cols": [
+      "date"
+    ],
+    "import_table": "import_cash_receipt",
+    "numeric_cols": [
+      "amount"
     ]
   },
   "dividend_announce": {
+    "date_cols": [
+      "ex_date"
+    ],
     "import_table": "import_dividend_announcement",
     "numeric_cols": [
       "amount",
       "gross",
       "net",
       "rate"
-    ],
-    "date_cols": [
-      "ex_date"
     ]
   },
   "fund_txn": {
+    "date_cols": [
+      "trade_date"
+    ],
     "import_table": "import_fund_purchase_redemption",
     "numeric_cols": [
       "shares",
       "nav",
       "amount"
-    ],
-    "date_cols": [
-      "trade_date"
+    ]
+  },
+  "gl_movement": {
+    "date_cols": [],
+    "import_table": "import_gl_movement",
+    "numeric_cols": [
+      "debit",
+      "credit",
+      "amount",
+      "balance"
+    ]
+  },
+  "product": {
+    "date_cols": [],
+    "import_table": "import_product",
+    "numeric_cols": [
+      "price",
+      "fee"
     ]
   },
   "reorg_announce": {
+    "date_cols": [],
     "import_table": "import_reorg_announcement",
     "numeric_cols": [
       "ratio",
       "cash_in_lieu"
-    ],
-    "date_cols": []
+    ]
   },
-  "account_migration": {
-    "import_table": "import_account_migration",
+  "seg_req": {
+    "date_cols": [],
+    "import_table": "import_seg_requirement",
     "numeric_cols": [
-      "opening_balance",
-      "credit_limit"
+      "requirement",
+      "balance",
+      "market_value"
+    ]
+  },
+  "stock_movement": {
+    "date_cols": [],
+    "import_table": "import_stock_movement",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "amount"
+    ]
+  },
+  "trade": {
+    "date_cols": [
+      "trade_date",
+      "settle_date"
     ],
-    "date_cols": []
+    "import_table": "import_trade",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "net_amount"
+    ]
+  },
+  "trade_cancel": {
+    "date_cols": [],
+    "import_table": "import_trade_cancel",
+    "numeric_cols": [
+      "qty",
+      "price",
+      "net_amount"
+    ]
   }
 }

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -24,17 +24,19 @@ def test_normalize_numeric_cell():
 
 def test_normalize_date_cell():
     cases = [
-        ("2023-01-02", "2023-01-02"),      # already ISO
-        ("01/02/2023", "2023-01-02"),      # slashes
-        ("2023/01/02", "2023-01-02"),      # ISO with slashes
-        ("02-03-2023", "2023-02-03"),      # dashes with month first
-        ("20230104", "2023-01-04"),        # compact digits
+        ("2023-01-02", "2023-01-02", False),  # already ISO
+        ("01/02/2023", "2023-01-02", True),  # slashes
+        ("2023/01/02", "2023-01-02", True),  # ISO with slashes
+        ("02-03-2023", "2023-02-03", True),  # dashes with month first
+        ("20230104", "2023-01-04", True),    # compact digits
+        ("", "", False),                    # empty remains empty
     ]
-    for raw, expected in cases:
+    for raw, expected, changed_flag in cases:
         out, changed, bad = normalize_date_cell(raw)
         assert out == expected
+        assert changed == changed_flag
         assert not bad
-    for bad_input in ["2023-13-01", "02/30/2023"]:
+    for bad_input in ["2023-13-01", "02/30/2023", "2023/13/01"]:
         out, changed, bad = normalize_date_cell(bad_input)
         assert bad
 


### PR DESCRIPTION
## Summary
- reorder rules to include `date_cols` entries for each batch type
- log invalid date values during CSV repair
- extend date normalization tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74ab4d2f4832d9f4af5e24a132dad