### PR TITLE
Add sample CSVs for all batch templates

### DIFF
--- a/tests/tests_csvs/sample_acats_cash.csv
+++ b/tests/tests_csvs/sample_acats_cash.csv
@@ -1,0 +1,3 @@
+# batch_type=acats_cash
+account,amount,description,cusip,contra_account,contra_description,contra_cusip,user
+ACC1,1,desc,CUSIP1,ACC1,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_acats_stock.csv
+++ b/tests/tests_csvs/sample_acats_stock.csv
@@ -1,0 +1,3 @@
+# batch_type=acats_stock
+account,custodian,location,quantity,description,cusip,contra_account,contra_custodian,contra_location,contra_description,user
+ACC1,CUST,LOC,1,desc,CUSIP1,ACC1,CUST,LOC,desc,user1

--- a/tests/tests_csvs/sample_account_migration.csv
+++ b/tests/tests_csvs/sample_account_migration.csv
@@ -1,0 +1,3 @@
+# batch_type=account_migration
+account_from,account_to
+ACC1,ACC1

--- a/tests/tests_csvs/sample_cash.csv
+++ b/tests/tests_csvs/sample_cash.csv
@@ -1,0 +1,3 @@
+# batch_type=cash
+trade_date,settle_date,account,account_type,currency,amount,type,remark,pay_bank_account,middle_bank_account,receive_bank_account,reference,dividend_product_id,dividend_custodian_code,dividend_custodian_account
+2023-01-01,2023-01-01,ACC1,ACC1,USD,1,TYPE,v8,ACC1,ACC1,ACC1,v12,PROD1,CUST,ACC1

--- a/tests/tests_csvs/sample_cash_journal.csv
+++ b/tests/tests_csvs/sample_cash_journal.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_journal
+account,amount,description,cusip,user
+ACC1,1,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_cash_movement.csv
+++ b/tests/tests_csvs/sample_cash_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_movement
+account,amount,description,cusip,contra_account,contra_description,contra_cusip,user
+ACC1,1,desc,CUSIP1,ACC1,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_cash_receipt.csv
+++ b/tests/tests_csvs/sample_cash_receipt.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_receipt
+type,account,amount,description,bank_account,ordering_customer_name,remittance_detail,senders_reference,sender_to_receiver_information,ordering_customer_address,ordering_bank_name,ordering_bank_address,ordering_bank_name2,ordering_bank_address2
+TYPE,ACC1,1,desc,ACC1,v6,v7,v8,v9,v10,v11,v12,v13,v14

--- a/tests/tests_csvs/sample_dividend_announce.csv
+++ b/tests/tests_csvs/sample_dividend_announce.csv
@@ -1,0 +1,3 @@
+# batch_type=dividend_announce
+event_id,event_type,description,record_date,pay_date,cusip,dividend_rate,currency,tax_exemption,m_v,allocated_amount
+EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,1,USD,v9,v10,1

--- a/tests/tests_csvs/sample_fund_txn.csv
+++ b/tests/tests_csvs/sample_fund_txn.csv
@@ -1,0 +1,3 @@
+# batch_type=fund_txn
+account,account_type,product_id,order_type,amount,price,redeem_fee
+ACC1,ACC1,PROD1,TYPE,1,1,1

--- a/tests/tests_csvs/sample_gl_movement.csv
+++ b/tests/tests_csvs/sample_gl_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=gl_movement
+credit_account,credit_sub_account,amount,description,debit_account,debit_sub_account
+1,1,1,desc,1,1

--- a/tests/tests_csvs/sample_product.csv
+++ b/tests/tests_csvs/sample_product.csv
@@ -1,0 +1,3 @@
+# batch_type=product
+trade_date,settle_date,product_id,account,account_type,custodian_code,custodian_account,quantity,avg_price,type,remark,reference,,
+2023-01-01,2023-01-01,PROD1,ACC1,ACC1,CUST,ACC1,1,1,TYPE,v11,v12,v13,v14

--- a/tests/tests_csvs/sample_reorg_announce.csv
+++ b/tests/tests_csvs/sample_reorg_announce.csv
@@ -1,0 +1,3 @@
+# batch_type=reorg_announce
+event_id,event_type,description,record_date,pay_date,cusip,to_cusip,rate_from,rate_to,m_v
+EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,CUSIP1,1,1,v10

--- a/tests/tests_csvs/sample_seg_req.csv
+++ b/tests/tests_csvs/sample_seg_req.csv
@@ -1,0 +1,3 @@
+# batch_type=seg_req
+account,account_type,cusip,from,to,quantity,description
+ACC1,ACC1,CUSIP1,FROM,TO,1,desc

--- a/tests/tests_csvs/sample_stock_movement.csv
+++ b/tests/tests_csvs/sample_stock_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=stock_movement
+account,custodian,location,quantity,description,cusip,contra_account,contra_custodian,contra_location,contra_description,user
+ACC1,CUST,LOC,1,desc,CUSIP1,ACC1,CUST,LOC,desc,user1

--- a/tests/tests_csvs/sample_trade.csv
+++ b/tests/tests_csvs/sample_trade.csv
@@ -1,0 +1,3 @@
+# batch_type=trade
+trade_date,settle_date,market,product_id,account,account_type,side,open_close,spc_code,external_id,clearing_account,destination_code,capacity,legend,trailer,quantity,currency,price,execution_time,execution_id,mpid,contra_mpid,fee1,fee2,fee3,fee4,fee5,sec_fee,commission
+2023-01-01,2023-01-01,MKT,PROD1,ACC1,ACC1,BUY,OPEN,SPC,EXT1,ACC1,DST1,CAP,LGND,TRL,1,USD,1,09:30:00,EXE1,MPID,MPID,1,1,1,1,1,1,0.5

--- a/tests/tests_csvs/sample_trade_cancel.csv
+++ b/tests/tests_csvs/sample_trade_cancel.csv
@@ -1,0 +1,3 @@
+# batch_type=trade_cancel
+orig_trade_id
+v1


### PR DESCRIPTION
## Summary
- supply sample CSV fixtures for every batch template with `# batch_type` headers
- drop unused template validation test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74febf2c8832dacb505f61fc02286