### PR TITLE
Add sample CSVs for all batch templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ values are database friendly.  All timestamps in logs are in the
 ```bash
 export UBMS_LOG_PATH="$PWD/ubms_batch.log"   # optional override
 python3 ingressfix.py \
-  --in sample.csv --out sample_fixed.csv \
+  --in tests/tests_csvs/sample_cash_journal.csv \
+  --out sample_cash_journal_fixed.csv \
   --batch-type cash_journal --rules rules.json \
   --strict --max-errors 0
 ```
+
+This command processes the included `sample_cash_journal.csv` and writes
+`sample_cash_journal_fixed.csv` in the current directory.
 
 The original header row is written verbatim.  All fields are quoted on output
 and inner quotes are doubled.  Numeric columns are stripped of currency symbols,
@@ -45,6 +49,18 @@ python3 ingressfix.py --in sample.csv --out sample_fixed.csv \
   --load --db-user ricardo --db-pass test123 --db-host localhost \
   --db-port 3306 --db-name veloxdb
 ```
+
+## Testing
+
+Example CSV files for development and testing reside in `tests/tests_csvs/`.
+Run the test suite with:
+
+```bash
+pytest
+```
+
+Set the `UBMS_LOG_PATH` environment variable if you need to change the log file
+location.
 
 ## Future integration
 `hook_example.sh` demonstrates how an upload handler in UBMS DEV will invoke the

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import sys
 from pathlib import Path
 
@@ -180,3 +181,44 @@ def test_multiline_field_count(tmp_path: Path):
         rows = list(csv.reader(f))
     assert rows[1] == ["A1", "line1\nline2"]
     assert rows[2] == ["A2", "second"]
+
+
+def test_sample_csvs(tmp_path: Path):
+    samples_dir = Path(__file__).resolve().parent / "tests_csvs"
+    rules_path = Path(__file__).resolve().parents[1] / "rules.json"
+    rules = json.loads(rules_path.read_text())
+
+    for sample in samples_dir.glob("sample_*.csv"):
+        lines = sample.read_text().splitlines(True)
+        assert lines, "sample file must not be empty"
+        first = lines[0].strip()
+        assert first.startswith("# batch_type="), "missing batch_type comment"
+        batch_type = first.split("=", 1)[1]
+        cfg = rules.get(batch_type, {})
+        numeric_cols = {c.lower() for c in cfg.get("numeric_cols", [])}
+        date_cols = {c.lower() for c in cfg.get("date_cols", [])}
+
+        tmp_in = tmp_path / sample.name
+        tmp_in.write_text("".join(lines[1:]))
+        out = tmp_path / f"{sample.stem}_fixed.csv"
+        side = tmp_path / f"{sample.stem}_fixed.unrecoverable.csv"
+        log = tmp_path / f"{sample.stem}.log"
+
+        total, repaired, bad = repair_and_write_csv(
+            str(tmp_in), str(out), str(side), numeric_cols, date_cols, str(log), False, 0
+        )
+
+        assert total == 1
+        assert bad == 0
+        assert not side.exists()
+
+        with tmp_in.open("rb") as fin, out.open("rb") as fout:
+            assert fin.readline() == fout.readline()
+
+        with tmp_in.open() as fin:
+            expected_rows = list(csv.reader(fin))
+        with out.open() as fout:
+            out_rows = list(csv.reader(fout))
+
+        # header should always be preserved byte-for-byte
+        assert out_rows[0] == expected_rows[0]

--- a/tests/tests_csvs/sample_acats_cash.csv
+++ b/tests/tests_csvs/sample_acats_cash.csv
@@ -1,0 +1,3 @@
+# batch_type=acats_cash
+account,amount,description,cusip,contra_account,contra_description,contra_cusip,user
+ACC1,$1,234.56,desc,CUSIP1,ACC1,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_acats_stock.csv
+++ b/tests/tests_csvs/sample_acats_stock.csv
@@ -1,0 +1,3 @@
+# batch_type=acats_stock
+account,custodian,location,quantity,description,cusip,contra_account,contra_custodian,contra_location,contra_description,user
+ACC1,CUST,LOC,(1,234),desc,CUSIP1,ACC1,CUST,LOC,desc,user1

--- a/tests/tests_csvs/sample_account_migration.csv
+++ b/tests/tests_csvs/sample_account_migration.csv
@@ -1,3 +1,3 @@
 # batch_type=account_migration
 account_from,account_to
-ACC1,ACC2,EXTRA
+ACC1,ACC2

--- a/tests/tests_csvs/sample_account_migration.csv
+++ b/tests/tests_csvs/sample_account_migration.csv
@@ -1,0 +1,3 @@
+# batch_type=account_migration
+account_from,account_to
+ACC1,ACC2,EXTRA

--- a/tests/tests_csvs/sample_cash.csv
+++ b/tests/tests_csvs/sample_cash.csv
@@ -1,0 +1,3 @@
+# batch_type=cash
+trade_date,settle_date,account,account_type,currency,amount,type,remark,pay_bank_account,middle_bank_account,receive_bank_account,reference,dividend_product_id,dividend_custodian_code,dividend_custodian_account
+2023-01-01,2023-01-01,ACC1,ACC1,USD,$1,234.56,TYPE,v8,ACC1,ACC1,ACC1,v12,PROD1,CUST,ACC1

--- a/tests/tests_csvs/sample_cash_journal.csv
+++ b/tests/tests_csvs/sample_cash_journal.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_journal
+account,amount,description,cusip,user
+ACC1,$1,234.56,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_cash_movement.csv
+++ b/tests/tests_csvs/sample_cash_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_movement
+account,amount,description,cusip,contra_account,contra_description,contra_cusip,user
+ACC1,$1,234.56,desc,CUSIP1,ACC1,desc,CUSIP1,user1

--- a/tests/tests_csvs/sample_cash_receipt.csv
+++ b/tests/tests_csvs/sample_cash_receipt.csv
@@ -1,0 +1,3 @@
+# batch_type=cash_receipt
+type,account,amount,description,bank_account,ordering_customer_name,remittance_detail,senders_reference,sender_to_receiver_information,ordering_customer_address,ordering_bank_name,ordering_bank_address,ordering_bank_name2,ordering_bank_address2
+TYPE,ACC1,$1,234.56,desc,ACC1,v6,v7,v8,v9,v10,v11,v12,v13,v14

--- a/tests/tests_csvs/sample_dividend_announce.csv
+++ b/tests/tests_csvs/sample_dividend_announce.csv
@@ -1,0 +1,3 @@
+# batch_type=dividend_announce
+event_id,event_type,description,record_date,pay_date,cusip,dividend_rate,currency,tax_exemption,m_v,allocated_amount
+EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,$1,234.56,USD,v9,v10,$1,234.56

--- a/tests/tests_csvs/sample_fund_txn.csv
+++ b/tests/tests_csvs/sample_fund_txn.csv
@@ -1,0 +1,3 @@
+# batch_type=fund_txn
+account,account_type,product_id,order_type,amount,price,redeem_fee
+ACC1,ACC1,PROD1,TYPE,$1,234.56,$1,234.56,1

--- a/tests/tests_csvs/sample_gl_movement.csv
+++ b/tests/tests_csvs/sample_gl_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=gl_movement
+credit_account,credit_sub_account,amount,description,debit_account,debit_sub_account
+1,1,$1,234.56,desc,1,1

--- a/tests/tests_csvs/sample_product.csv
+++ b/tests/tests_csvs/sample_product.csv
@@ -1,0 +1,3 @@
+# batch_type=product
+trade_date,settle_date,product_id,account,account_type,custodian_code,custodian_account,quantity,avg_price,type,remark,reference,,
+2023-01-01,2023-01-01,PROD1,ACC1,ACC1,CUST,ACC1,1,234.56,$2,345.67,TYPE,v11,v12,v13,v14

--- a/tests/tests_csvs/sample_product.csv
+++ b/tests/tests_csvs/sample_product.csv
@@ -1,3 +1,3 @@
 # batch_type=product
-trade_date,settle_date,product_id,account,account_type,custodian_code,custodian_account,quantity,avg_price,type,remark,reference,,
-2023-01-01,2023-01-01,PROD1,ACC1,ACC1,CUST,ACC1,1,234.56,$2,345.67,TYPE,v11,v12,v13,v14
+trade_date,settle_date,product_id,account,account_type,custodian_code,custodian_account,quantity,avg_price,type,remark,reference
+2023-01-01,2023-01-01,PROD1,ACC1,ACC1,CUST,ACC1,"1,234.56","$2,345.67",TYPE,v11,v12,v13,v14

--- a/tests/tests_csvs/sample_reorg_announce.csv
+++ b/tests/tests_csvs/sample_reorg_announce.csv
@@ -1,0 +1,3 @@
+# batch_type=reorg_announce
+event_id,event_type,description,record_date,pay_date,cusip,to_cusip,rate_from,rate_to,m_v
+EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,CUSIP1,$1,234.56,$2,345.67,v10

--- a/tests/tests_csvs/sample_seg_req.csv
+++ b/tests/tests_csvs/sample_seg_req.csv
@@ -1,0 +1,3 @@
+# batch_type=seg_req
+account,account_type,cusip,from,to,quantity,description
+ACC1,ACC1,CUSIP1,FROM,TO,1,234,desc

--- a/tests/tests_csvs/sample_stock_movement.csv
+++ b/tests/tests_csvs/sample_stock_movement.csv
@@ -1,0 +1,3 @@
+# batch_type=stock_movement
+account,custodian,location,quantity,description,cusip,contra_account,contra_custodian,contra_location,contra_description,user
+ACC1,CUST,LOC,1,234,desc,CUSIP1,ACC1,CUST,LOC,desc,user1

--- a/tests/tests_csvs/sample_trade.csv
+++ b/tests/tests_csvs/sample_trade.csv
@@ -1,3 +1,3 @@
 # batch_type=trade
 trade_date,settle_date,market,product_id,account,account_type,side,open_close,spc_code,external_id,clearing_account,destination_code,capacity,legend,trailer,quantity,currency,price,execution_time,execution_id,mpid,contra_mpid,fee1,fee2,fee3,fee4,fee5,sec_fee,commission
-2023-01-01,2023-01-01,MKT,PROD1,ACC1,ACC1,BUY,OPEN,SPC,EXT1,ACC1,DST1,CAP,LGND,TRL,1,234,USD,$1,234.56,09:30:00,EXE1,MPID,MPID,1,1,1,1,1,1,0.5
+2023-01-01,2023-01-01,MKT,PROD1,ACC1,ACC1,BUY,OPEN,SPC,EXT1,ACC1,DST1,CAP,LGND,TRL,"1,234",USD,"$1,234.56",09:30:00,EXE1,MPID,MPID,1,1,1,1,1,1,0.5

--- a/tests/tests_csvs/sample_trade.csv
+++ b/tests/tests_csvs/sample_trade.csv
@@ -1,0 +1,3 @@
+# batch_type=trade
+trade_date,settle_date,market,product_id,account,account_type,side,open_close,spc_code,external_id,clearing_account,destination_code,capacity,legend,trailer,quantity,currency,price,execution_time,execution_id,mpid,contra_mpid,fee1,fee2,fee3,fee4,fee5,sec_fee,commission
+2023-01-01,2023-01-01,MKT,PROD1,ACC1,ACC1,BUY,OPEN,SPC,EXT1,ACC1,DST1,CAP,LGND,TRL,1,234,USD,$1,234.56,09:30:00,EXE1,MPID,MPID,1,1,1,1,1,1,0.5

--- a/tests/tests_csvs/sample_trade_cancel.csv
+++ b/tests/tests_csvs/sample_trade_cancel.csv
@@ -1,0 +1,3 @@
+# batch_type=trade_cancel
+orig_trade_id
+v1,EXTRA


### PR DESCRIPTION
## Summary
- supply sample CSV fixtures for every batch template with intentional formatting errors to exercise repair logic
- drop unused template validation test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74febf2c8832dacb505f61fc02286