### PR TITLE
Handle leading comment lines in ingress CSVs

### DIFF
--- a/ingressfix.py
+++ b/ingressfix.py
@@ -237,9 +237,20 @@ def repair_and_write_csv(in_path: str, out_path: str, sidecar_path: str,
             log_warn("Empty file; nothing to do", log_path)
             return (0,0,0)
 
-        # write the header exactly as read, preserving original newline
-        fout.write(first_line)
-        header = next(csv.reader([first_line]))
+        # handle optional leading comment like "# batch_type=..."
+        if first_line.lstrip().startswith("#"):
+            fout.write(first_line)  # preserve comment line
+            header_line = fin.readline()
+            if not header_line:
+                log_warn("Missing header after comment line; nothing to do", log_path)
+                return (0,0,0)
+            fout.write(header_line)
+            header = next(csv.reader([header_line]))
+        else:
+            # write the header exactly as read, preserving original newline
+            fout.write(first_line)
+            header = next(csv.reader([first_line]))
+
         # writer is only used for subsequent rows
         writer = csv.writer(fout, quoting=csv.QUOTE_ALL)
 

--- a/tests/test_ingressfix.py
+++ b/tests/test_ingressfix.py
@@ -94,6 +94,26 @@ def test_header_preserved(tmp_path: Path):
 
     with inp.open('rb') as fin, out.open('rb') as fout:
         assert fin.readline() == fout.readline()
+
+
+def test_comment_line_before_header(tmp_path: Path):
+    inp = tmp_path / "with_comment.csv"
+    inp.write_text("# batch_type=foo\ncol1,col2\nv1,1\n")
+    out = tmp_path / "with_comment_fixed.csv"
+    side = tmp_path / "with_comment_fixed.unrecoverable.csv"
+    log = tmp_path / "test.log"
+
+    total, repaired, bad = repair_and_write_csv(
+        str(inp), str(out), str(side), set(), set(), str(log), False, 0
+    )
+    assert total == 1 and bad == 0
+
+    with out.open() as f:
+        first = f.readline().strip()
+        assert first == "# batch_type=foo"
+        rows = list(csv.reader(f))
+    assert rows[0] == ["col1", "col2"]
+    assert rows[1] == ["v1", "1"]
 def test_date_normalization(tmp_path: Path):
     inp = tmp_path / "dates.csv"
     inp.write_text(


### PR DESCRIPTION
## Summary
- handle optional leading comment line before the header in CSV files
- add regression test to ensure comment line is preserved and data parsed correctly

## Testing
- `pytest -q`
- `python3 ingressfix.py --in tests/tests_csvs/sample_acats_cash.csv --out /tmp/sample_acats_cash_fixed.csv --batch-type acats_cash --rules rules.json`

------
https://chatgpt.com/codex/tasks/task_e_68a760ae0d3c832d8a54d44d0f050e8b