### PR TITLE
Add tests for numeric/date mismatch, comma heuristics, and sidecar creation

### DIFF
--- a/tests/tests_csvs/mixed_commas.csv
+++ b/tests/tests_csvs/mixed_commas.csv
@@ -1,0 +1,2 @@
+amount,description
+1,234,desc,with comma


### PR DESCRIPTION
## Summary
- verify warnings when numeric_cols and date_cols names don't match header
- add CSV fixture and test for heuristic rebuild when numeric and text fields contain commas
- ensure sidecar file is created only for unrecoverable rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a77ee55aec832da25fe3457adeba19