### PR TITLE
Clean up table rules and samples

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -21,10 +21,7 @@
     "column_count": 2,
     "date_cols": [],
     "import_table": "import_account_migration",
-    "numeric_cols": [
-      "opening_balance",
-      "credit_limit"
-    ]
+    "numeric_cols": []
   },
   "cash": {
     "column_count": 15,
@@ -118,8 +115,8 @@
     "date_cols": [],
     "import_table": "import_reorg_announcement",
     "numeric_cols": [
-      "ratio",
-      "cash_in_lieu"
+      "rate_from",
+      "rate_to"
     ]
   },
   "seg_req": {
@@ -159,10 +156,6 @@
     "column_count": 1,
     "date_cols": [],
     "import_table": "import_trade_cancel",
-    "numeric_cols": [
-      "qty",
-      "price",
-      "net_amount"
-    ]
+    "numeric_cols": []
   }
 }

--- a/tests/tests_csvs/sample_reorg_announce.csv
+++ b/tests/tests_csvs/sample_reorg_announce.csv
@@ -1,3 +1,3 @@
 # batch_type=reorg_announce
 event_id,event_type,description,record_date,pay_date,cusip,to_cusip,rate_from,rate_to,m_v
-EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,CUSIP1,$1,234.56,$2,345.67,v10
+EVT1,TYPE,desc,2023-01-01,2023-01-01,CUSIP1,CUSIP1,1234.56,2345.67,v10

--- a/tests/tests_csvs/sample_trade_cancel.csv
+++ b/tests/tests_csvs/sample_trade_cancel.csv
@@ -1,3 +1,3 @@
 # batch_type=trade_cancel
 orig_trade_id
-v1,EXTRA
+v1


### PR DESCRIPTION
## Summary
- Remove obsolete numeric columns from account_migration
- Correct trade_cancel rules and sample
- Align reorg_announce numeric columns and sample

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a780a5ac64832da85f407d3deb5556