### PR TITLE
docs: add dev usage examples and clarify hook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ values are database friendly.  All timestamps in logs are in the
 * Python 3.10+
 * Optional: [`PyMySQL`](https://pymysql.readthedocs.io/) when using `--load`
 
-## Basic usage
+## Usage examples
+
+### Local development
+
 ```bash
 export UBMS_LOG_PATH="$PWD/ubms_batch.log"   # optional override
 python3 ingressfix.py \
@@ -21,6 +24,19 @@ python3 ingressfix.py \
 
 This command processes the included `sample_cash_journal.csv` and writes
 `sample_cash_journal_fixed.csv` in the current directory.
+
+### UBMS DEV environment
+
+```bash
+export UBMS_LOG_PATH="/opt/tasks/log/ubms_batch.log"  # default on UBMS hosts
+python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \
+  --in "$SRC" --out "$DST" --batch-type "$TYPE" \
+  --rules /home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json \
+  --strict --max-errors 0 --log "$UBMS_LOG_PATH"
+```
+
+Paths reflect UBMS DEV conventions. Adjust them and `UBMS_LOG_PATH` as needed to
+redirect logs.
 
 The original header row is written verbatim.  All fields are quoted on output
 and inner quotes are doubled.  Numeric columns are stripped of currency symbols,
@@ -71,10 +87,11 @@ pytest
 Set the `UBMS_LOG_PATH` environment variable if you need to change the log file
 location.
 
-## Future integration
-`hook_example.sh` demonstrates how an upload handler in UBMS DEV will invoke the
-fixer and then pass the `_fixed.csv` file to existing loaders.  TODO markers in
-code note areas that may require adjustments during real deployment.
+## Upload handler integration
+`scripts/hook_example.sh` illustrates how a UBMS upload handler could invoke the
+fixer and then hand the `_fixed.csv` file to existing loaders.  TODO comments in
+the script mark paths—`RULES`, `ingressfix.py`, and `UBMS_LOG_PATH`—that should
+be updated for the target environment.
 
 ## Production configuration
 Update placeholder values before deploying:

--- a/scripts/hook_example.sh
+++ b/scripts/hook_example.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-# Example: how the UBMS upload handler could invoke the fixer.
+# Example: UBMS upload handler invoking the fixer.
 # Inputs: $1=type (e.g., cash_journal), $2=src_csv, $3=dst_csv (fixed)
+# TODO markers highlight values to update for the target environment.
 set -euo pipefail
 TYPE="$1"; SRC="$2"; DST="$3"
 
-RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"  # TODO: adjust RULES path for target environment
-LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"  # TODO: configure log path or UBMS_LOG_PATH for target environment
+# TODO: adjust RULES path for target environment
+RULES="/home/settle/ubms_pro/server/template/ubms_csv_fix/rules.json"
 
-python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \  # TODO: adjust ingressfix.py path for target environment
+# TODO: configure log path or set UBMS_LOG_PATH for target environment
+LOG="${UBMS_LOG_PATH:-/opt/tasks/log/ubms_batch.log}"
+
+# TODO: adjust ingressfix.py path for target environment
+python3 /home/settle/ubms_pro/server/template/ubms_csv_fix/ingressfix.py \
   --in "$SRC" --out "$DST" --batch-type "$TYPE" --rules "$RULES" \
   --max-errors 0 --strict --log "$LOG"
 # then pass "$DST" to the existing loader...


### PR DESCRIPTION
## Summary
- document local and UBMS DEV usage examples, including UBMS_LOG_PATH and UBMS file paths
- explain upload handler integration and TODO adjustments in hook_example.sh
- clean up hook_example.sh formatting so comments and commands stay on separate lines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7823bf16c832da92be75a033895c7