### PR TITLE
Refactor ingress fixer to use MyLog and MySqlAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ values are database friendly.  All timestamps in logs are in the
 
 ## Requirements
 * Python 3.10+
-* Optional: [`PyMySQL`](https://pymysql.readthedocs.io/) when using `--load`
+* Optional: MySqlAdapter (uses PyMySQL) when using `--load`
+
+## Logging
+Developer logs are written via MyLog to `./log/YYYYMMDD.log` while a second
+Zabbix-friendly stream is appended to the central file specified by
+`UBMS_LOG_PATH` or `--log` (default `/opt/tasks/log/ubms_batch.log`).
 
 ## Usage examples
 
@@ -66,7 +71,7 @@ done
 
 ## Optional local DB load
 When `--load` is supplied the tool loads the fixed file into MySQL using a
-temporary table.  Example with local development credentials:
+temporary table via `mysql_adapter.MySqlAdapter`. Example with local development credentials:
 
 ```bash
 python3 ingressfix.py --in sample.csv --out sample_fixed.csv \

--- a/scripts/hook_example.sh
+++ b/scripts/hook_example.sh
@@ -2,6 +2,7 @@
 # Example: UBMS upload handler invoking the fixer.
 # Inputs: $1=type (e.g., cash_journal), $2=src_csv, $3=dst_csv (fixed)
 # TODO markers highlight values to update for the target environment.
+# ingressfix.py relies on MySqlAdapter and MyLog wrappers included with the server template.
 set -euo pipefail
 TYPE="$1"; SRC="$2"; DST="$3"
 


### PR DESCRIPTION
## Summary
- replace custom file logging with MyLog and mirror messages to a Zabbix-friendly central log
- route all database operations through mysql_adapter.MySqlAdapter
- document dual logging and adapter usage

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78e8b9490832d990721edaa491dfa